### PR TITLE
Split extra valgrind tools to separate package

### DIFF
--- a/rpm/valgrind.spec
+++ b/rpm/valgrind.spec
@@ -101,7 +101,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root)
-%doc COPYING NEWS README_*
+%doc COPYING
 %{_bindir}/valgrind
 %{_bindir}/valgrind-di-server
 %{_bindir}/valgrind-listener
@@ -129,4 +129,6 @@ rm -rf $RPM_BUILD_ROOT
 %files doc
 %defattr(-,root,root)
 %doc docs.installed/html docs.installed/*.pdf
+%doc NEWS README_*
 %{_mandir}/man1/*
+

--- a/rpm/valgrind.spec
+++ b/rpm/valgrind.spec
@@ -80,6 +80,7 @@ make %{_smp_mflags}
 rm -rf $RPM_BUILD_ROOT
 
 %makeinstall
+rm -rf docs.installed
 mkdir docs.installed
 mv $RPM_BUILD_ROOT%{_datadir}/doc/valgrind/* docs.installed/
 rm -f docs.installed/*.ps

--- a/rpm/valgrind.spec
+++ b/rpm/valgrind.spec
@@ -27,6 +27,14 @@ malloc/new/free/delete are intercepted. As a result, Valgrind can
 detect a lot of problems that are otherwise very hard to
 find/diagnose.
 
+%package extratools
+Summary: Additional tools for Valgrind (requires Perl)
+Requires: valgrind = %{version}-%{release}
+
+%description extratools
+Additional tools for Valgrind. Includes callgrind and ms_print.
+These depend on Perl support so might pull in lot of dependencies.
+
 %package devel
 Summary: Development files for valgrind
 Group: Development/Debuggers
@@ -94,10 +102,22 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root)
 %doc COPYING NEWS README_*
-%{_bindir}/*
+%{_bindir}/valgrind
+%{_bindir}/valgrind-di-server
+%{_bindir}/valgrind-listener
+%{_bindir}/vgdb
 %dir %{_libdir}/valgrind
 %{_libdir}/valgrind/*[^ao]
 %{_libdir}/valgrind/[^l]*o
+
+%files extratools
+%defattr(-,root,root)
+%{_bindir}/callgrind_annotate
+%{_bindir}/callgrind_control
+%{_bindir}/cg_annotate
+%{_bindir}/cg_diff
+%{_bindir}/cg_merge
+%{_bindir}/ms_print
 
 %files devel
 %defattr(-,root,root)


### PR DESCRIPTION
Callgrind and ms_print require Perl. Splitting them into separate
package saves user from having to need it installed if he/she cares
only about the main Valgrind tool.

@saukko @abranson 