### PR TITLE
[rpm] Require glibc-debuginfo. Contributes to JB#44249

### DIFF
--- a/rpm/valgrind.spec
+++ b/rpm/valgrind.spec
@@ -9,6 +9,7 @@ URL: http://www.valgrind.org/
 Group: Development/Debuggers
 ExclusiveArch: %{ix86} %{arm}
 BuildRequires: pkgconfig
+Requires: glibc-debuginfo
 
 %ifarch %{ix86}
 %define valarch x86


### PR DESCRIPTION
Without installing glibc-debuginfo (glibc-debugsource is also needed but
is pulled as dependency of glibc-debuginfo) valgrind refuses to work with
following message:

```
valgrind:  Fatal error at startup: a function redirection
valgrind:  which is mandatory for this platform-tool combination
valgrind:  cannot be set up.  Details of the redirection are:
valgrind:
valgrind:  A must-be-redirected function
valgrind:  whose name matches the pattern:      strcmp
valgrind:  in an object with soname matching:   ld-linux-armhf.so.3
valgrind:  was not found whilst processing
valgrind:  symbols from the object with soname: ld-linux-armhf.so.3
valgrind:
valgrind:  Possible fixes: (1, short term): install glibc's debuginfo
valgrind:  package on this machine.  (2, longer term): ask the packagers
valgrind:  for your Linux distribution to please in future ship a non-
valgrind:  stripped ld.so (or whatever the dynamic linker .so is called)
valgrind:  that exports the above-named function using the standard
valgrind:  calling conventions for this platform.  The package you need
valgrind:  to install for fix (1) is called
valgrind:
valgrind:    On Debian, Ubuntu:                 libc6-dbg
valgrind:    On SuSE, openSuSE, Fedora, RHEL:   glibc-debuginfo
valgrind:
valgrind:  Note that if you are debugging a 32 bit process on a
valgrind:  64 bit system, you will need a corresponding 32 bit debuginfo
valgrind:  package (e.g. libc6-dbg:i386).
valgrind:
valgrind:  Cannot continue -- exiting now.  Sorry.
```