### PR TITLE
[valgrind] Add automake as a build dependency. Fixes JB#59410

### DIFF
--- a/rpm/valgrind.spec
+++ b/rpm/valgrind.spec
@@ -10,6 +10,7 @@ Patch0: 0001-VEX-priv-guest_arm_toIR.c-fix-0xEBAD-0x1CCA-sub.w-r1.patch
 License: GPLv2
 URL: http://www.valgrind.org/
 Requires: glibc-debuginfo
+BuildRequires: automake
 
 %ifarch %{ix86}
 %define valarch x86


### PR DESCRIPTION
Since automake isn't installed by default on the application sdk, the build requirement is needed for it to be buildable there.